### PR TITLE
PR triggered build fixes

### DIFF
--- a/src/main/java/com/carolynvs/gitallthethings/pullrequests/PullRequestBuildContext.java
+++ b/src/main/java/com/carolynvs/gitallthethings/pullrequests/PullRequestBuildContext.java
@@ -19,7 +19,7 @@ public class PullRequestBuildContext
         Map<String, VariableDefinitionContext> buildVars = buildContext.getVariableContext().getEffectiveVariables();
 
         if (!buildVars.containsKey(PULLREQUEST_NUMBER_VAR) || !buildVars.containsKey(PULLREQUEST_STATUS_URL_VAR)) {
-            logger.addErrorLogEntry("The pullrequest variables are not set. If you are running a manual build, you must set the pullrequest.number and pullrequest.statusurl variables, i.e. run a customized build and override these variables with the desired pull request and the URL to which the status should be reported.");
+            logger.addBuildLogEntry("The pullrequest variables are not set. If you are running a manual build, you must set the pullrequest.number and pullrequest.statusurl variables, i.e. run a customized build and override these variables with the desired pull request and the URL to which the status should be reported.");
             return null;
         }
 

--- a/src/main/resources/admin/configureGitAllTheThings.ftl
+++ b/src/main/resources/admin/configureGitAllTheThings.ftl
@@ -42,6 +42,7 @@
                 <em>Payload URL</em> is http://BAMBOO_URL/bamboo/rest/github-webhook/1.0/pullrequest-trigger/PLAN_KEY.
                 Replace <strong>BAMBOO_URL</strong> with your Bamboo installation URL (including the port) and
                 <strong>PLAN_KEY</strong> with the plan key where pull request branch builds should be created.
+                Depending on your Bamboo installation you may need to omit <em>/bamboo</em> from the URL.
             </li>
             <li>
                 <em>Content Type</em> is <strong>application/json</strong>.
@@ -61,6 +62,10 @@
     <li>
         <em>Bot Name</em> is the name displayed in Bamboo as the user which triggered a build when a pull request is
         created or updated.
+    </li>
+    <li>
+        Ensure your Bamboo build plan has View permissions for anonymous users.
+        Navigate to the plan configuration, permissions tab. Tick the box so that <em>Other Users</em> are permitted to <em>View</em>.
     </li>
 </ol>
 </body>


### PR DESCRIPTION
Manual builds no longer produce error because they are not from a GitHub PR. Fixes #1 